### PR TITLE
Activation Reminder

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -35,7 +35,7 @@ resource "aws_rds_cluster" "app2-rds-cluster" {
 resource "aws_rds_cluster" "app3-rds-cluster" {
   cluster_identifier      = "app3-rds-cluster"
   allocated_storage       = 10
-  backup_retention_period = 15
+  backup_retention_period = 16
   tags = {
     git_commit           = "079fe74f6b96d887c245664fbd8cf676c92f20e5"
     git_file             = "terraform/aws/rds.tf"


### PR DESCRIPTION
Our reminder comment allows you to boos extension activation by reminding every other week people opening PRs on branches not scanned in our extension that they would go faster by scanning in their code directly in the IDE. 